### PR TITLE
Issue 3

### DIFF
--- a/Sources/Terminus/Core/Cursor.swift
+++ b/Sources/Terminus/Core/Cursor.swift
@@ -23,9 +23,6 @@ public struct Cursor {
             return nil
             //throw TerminalError.failedToReadTerminalResponse(message: "")
         }
-
-
-       
     }
 
     public init() {}

--- a/Sources/Terminus/UIControls/LineEditor.swift
+++ b/Sources/Terminus/UIControls/LineEditor.swift
@@ -254,7 +254,7 @@ open class LineEditor {
             let startBufferHeight = bufferHeight()
             let endCursorPosition = terminal.endCursorLocationFor(stringToDisplay: key.rawValue)
             if let index = bufferIndexForLocation(startWriteLocation) {
-                buffer.insert(AttributedString(key.rawValue), at: index)
+                buffer.insert(AttributedString(keyString), at: index)
             }
             let endBufferHeight = bufferHeight()
             if endBufferHeight > startBufferHeight && startLocation.y + endBufferHeight - 1 > textAreaSize.height {

--- a/Tests/TerminusTests/CursorTests.swift
+++ b/Tests/TerminusTests/CursorTests.swift
@@ -11,7 +11,7 @@ class CursorTests: XCTestCase {
     
     override func setUpWithError() throws {
         sut = Cursor()
-
+        terminal = Terminal.shared
     }
     
     override func tearDownWithError() throws {


### PR DESCRIPTION
# Closes #3 

Copy/paste in the LineEditor (and elsewhere) is now correctly displayed in the terminal.
## Changes
* Internal fixes to the buffering system used in LineEditor
* Fixed a bug in terminal writes that occasionally causes the cursor to hang at the end of a line.

## Notes
* extremely long blobs of text that push the starting location of the LineEditor outside of the visible terminal window will still cause things to break 
